### PR TITLE
Fix vercel route for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# Gerador-propostas-MEIs
+# Gerador de Propostas MEI
+
+Aplicação web para criação de propostas comerciais personalizadas para microempreendedores individuais.
+
+## Funcionalidades
+- Formulário interativo para dados de empresa e cliente
+- Cadastro de itens com cálculo de valor total
+- Personalização de cores e inclusão de logo
+- Pré-visualização em tempo real
+- Geração de PDF com [jsPDF](https://github.com/parallax/jsPDF)
+- Compartilhamento rápido via WhatsApp
+- Limite gratuito de três propostas por mês
+
+## Tecnologias
+- [React](https://react.dev) + [Vite](https://vitejs.dev)
+- [Tailwind CSS](https://tailwindcss.com) e Radix UI
+- [jsPDF](https://github.com/parallax/jsPDF)
+
+## Instalação
+```bash
+npm install
+```
+
+## Ambiente de desenvolvimento
+```bash
+npm run dev
+```
+
+Para gerar a versão de produção:
+```bash
+npm run build
+npm run preview
+```
+
+Acesse `http://localhost:5173` em seu navegador e preencha os campos para gerar a proposta.
+
+## Release Notes
+### v0.1.1
+- Correção na importação do jsPDF que causava erro ao gerar PDFs
+
+### v0.1.0
+- Primeira versão da aplicação com geração de propostas e download em PDF

--- a/src/lib/pdfGenerator.js
+++ b/src/lib/pdfGenerator.js
@@ -1,5 +1,5 @@
 
-import jsPDF from 'jspdf';
+import { jsPDF } from 'jspdf';
 
 export const generatePDF = async (data) => {
   const pdf = new jsPDF();

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,11 @@
 {
   "version": 2,
   "builds": [
-    { "src": "next.config.js", "use": "@vercel/next" }
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
   ],
   "routes": [
-    { "src": "/api/(.*)", "dest": "/api/$1.js" }
+    { "src": "/api/(.*)", "dest": "/pages/api/$1.js" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- update Vercel config to correctly serve API routes from `pages/api`
- configure static build output
- fallback to `index.html` for SPA routing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68668fbd0ad08328923ba8dc34e17f9a

## Resumo por Sourcery

Correção da configuração do Vercel para rotas de API, correção da importação do jsPDF e aprimoramento da documentação do projeto.

Correções de bugs:
- Correção da importação do jsPDF para usar a importação nomeada em pdfGenerator

Implantação:
- Atualização da configuração do Vercel para servir rotas de API de pages/api, definir o diretório de saída estático e usar index.html como fallback para roteamento SPA

Documentação:
- Expansão do README com visão geral do projeto, recursos, stack de tecnologias, instalação, desenvolvimento e notas de lançamento

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Vercel configuration for API routes, correct jsPDF import, and enhance project documentation.

Bug Fixes:
- Correct jsPDF import to use named import in pdfGenerator

Deployment:
- Update Vercel config to serve API routes from pages/api, set static output directory, and fallback to index.html for SPA routing

Documentation:
- Expand README with project overview, features, tech stack, installation, development and release notes

</details>