### PR TITLE
Add Vercel analytics integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Aplicação web para criação de propostas comerciais personalizadas para micro
 - [React](https://react.dev) + [Vite](https://vitejs.dev)
 - [Tailwind CSS](https://tailwindcss.com) e Radix UI
 - [jsPDF](https://github.com/parallax/jsPDF)
+- [Vercel Web Analytics](https://vercel.com/docs/analytics) e [Speed Insights](https://vercel.com/docs/speed-insights)
 
 ## Instalação
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.5",
+        "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "framer-motion": "^10.16.4",
@@ -4032,6 +4034,79 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.5",
+    "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "framer-motion": "^10.16.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Toaster } from '@/components/ui/toaster';
 import ProposalGenerator from '@/components/ProposalGenerator';
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
 
 function App() {
   return (
@@ -15,6 +17,8 @@ function App() {
       <div className="min-h-screen">
         <ProposalGenerator />
         <Toaster />
+        <Analytics />
+        <SpeedInsights />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- install `@vercel/analytics` and `@vercel/speed-insights`
- show Vercel analytics in technologies list
- add `<Analytics />` and `<SpeedInsights />` components in the app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68680dc0601c8328a7545077181c1d9f

## Resumo por Sourcery

Integra a análise e os insights de desempenho do Vercel na aplicação, instalando os pacotes necessários, incorporando os seus componentes React e atualizando a documentação do projeto.

Novas funcionalidades:
- Instala `@vercel/analytics` e `@vercel/speed-insights` e incorpora os componentes `<Analytics />` e `<SpeedInsights />` na App principal

Documentação:
- Adiciona o Vercel Web Analytics e o Speed Insights à lista de tecnologias no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Vercel analytics and performance insights into the application by installing the necessary packages, embedding their React components, and updating project documentation.

New Features:
- Install `@vercel/analytics` and `@vercel/speed-insights` and embed `<Analytics />` and `<SpeedInsights />` components in the main App

Documentation:
- Add Vercel Web Analytics and Speed Insights to the technology list in the README

</details>